### PR TITLE
Jon/bigquery timestamp support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,15 +96,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>lib/</classpathPrefix>
-              <mainClass>com.github.yuiskw.beam.BigQuery2Datastore</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
       </plugin>
 
       <!--

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>com.github.yuiskw.beam.BigQuery2Datastore</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
       </plugin>
 
       <!--

--- a/src/main/java/com/github/yuiskw/beam/TableRow2EntityFn.java
+++ b/src/main/java/com/github/yuiskw/beam/TableRow2EntityFn.java
@@ -303,6 +303,7 @@ public class TableRow2EntityFn extends DoFn<TableRow, Entity> {
         "yyyy-M-d H:m:s.SSS z",
         "yyyy-M-d H:m:s.SS z",
         "yyyy-M-d H:m:s.S z",
+        "yyyy-M-d H:m:s z",
         "yyyy-M-d H:m:s.SSS",
         "yyyy-M-d H:m:s.SS",
         "yyyy-M-d H:m:s.S",

--- a/src/test/java/com/github/yuiskw/beam/TableRow2EntityFnTest.java
+++ b/src/test/java/com/github/yuiskw/beam/TableRow2EntityFnTest.java
@@ -166,6 +166,7 @@ public class TableRow2EntityFnTest {
     assertNotNull(TableRow2EntityFn.parseTimestamp("2017-9-1 4:1:1.1 UTC"));
     assertNotNull(TableRow2EntityFn.parseTimestamp("2017-9-1 4:1:1.12 UTC"));
     assertNotNull(TableRow2EntityFn.parseTimestamp("2017-9-1 4:1:1.001 UTC"));
+    assertNotNull(TableRow2EntityFn.parseTimestamp("2019-03-13 22:00:20 UTC"));
 
     assertNotNull(TableRow2EntityFn.parseTimestamp("2017-09-16 04:14:37.844 PST"));
     assertNotNull(TableRow2EntityFn.parseTimestamp("2017-09-16 04:14:37.844 JST"));


### PR DESCRIPTION
Adding support for to convert a BigQuery `TIMESTAMP` value that does not have millisecond precision but has a timezone to be converted to a Datastore `timestamp` value.

Also adding a manifest property to the `pom.xml` to point to the Apache Beam job entry point